### PR TITLE
PR: inverse_transform is implemented for scikit-learn utility 

### DIFF
--- a/ugtm/ugtm_sklearn.py
+++ b/ugtm/ugtm_sklearn.py
@@ -145,7 +145,10 @@ class eGTM(BaseEstimator, TransformerMixin):
         dic["modes"] = self.projected.matModes
         dic["responsibilities"] = self.projected.matR
 
-        return dic[model]
+        if model is not None:
+            return dic[model]
+        else:
+            return dic["means"]
 
     def fit_transform(self, X, model="means"):
         """Fits and transforms X using GTM.
@@ -196,8 +199,24 @@ class eGTM(BaseEstimator, TransformerMixin):
         dic["means"] = self.projected.matMeans
         dic["modes"] = self.projected.matModes
         dic["responsibilities"] = self.projected.matR
+        if model is not None:
+            return dic[model]
+        else:
+            return dic["means"]
 
-        return dic[model]
+    def inverse_transform(self, matR):
+        """Inverse transformation of responsibility onto the original data space
+
+        Parameters
+        ==========
+        matR : array of shape (n_samples, n_nodes)
+
+        Returns
+        =======
+        matY : array of shape (n_samples, n_dimensions)
+        """
+        weightedPhi = np.dot(matR, self.initialModel.matPhiMPlusOne)
+        return np.dot(weightedPhi, self.optimizedModel.matW.T)
 
 
 class eGTC(BaseEstimator, ClassifierMixin):


### PR DESCRIPTION
Hello, 

I have found that there is no `inverse_transform`, which of PCA is found in [scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PCA.inverse_transform).
A new method `inverse_transform` in this PR maps responsibilities onto the original data space. 

The short sample code is here:
```python 
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split
from ugtm.ugtm_sklearn import eGTM
X,y = load_iris(return_X_y=True)
Xtrain, Xtest = train_test_split(X, test_size=0.20,
                random_state=42)
model = eGTM()
_ = model.fit_transform( Xtrain )
matR = model.transform(Xtest, model='responsibilities')
Xhat = model.inverse_transform(matR)
print("original data", Xtest.shape)
print("projected data", Xhat.shape)
#original data (30, 4)
#projected data (30, 4)
``` 

This may help analyses with GTM.
Thank you in advance for your consideration.